### PR TITLE
Fix internal server error 500 caused by conflict with FacetWP version 2.7.2

### DIFF
--- a/classes/p2p.php
+++ b/classes/p2p.php
@@ -80,10 +80,10 @@ class FacetWP_Facet_P2P {
 		$selected_values = (array) $params['selected_values'];
 
 		foreach ( $values as $result ) {
-			$selected = in_array( $result->facet_value, $selected_values ) ? ' checked' : '';
-			$selected .= ( 0 == $result->counter ) ? ' disabled' : '';
-			$output .= '<div class="facetwp-p2p' . $selected . '" data-value="' . $result->facet_value . '">';
-			$output .= $result->facet_display_value . ' <span class="facetwp-counter">(' . $result->counter . ')</span>';
+			$selected = in_array( $result['facet_value'], $selected_values ) ? ' checked' : '';
+			$selected .= ( 0 == $result['counter'] ) ? ' disabled' : '';
+			$output .= '<div class="facetwp-p2p' . $selected . '" data-value="' . $result['facet_value'] . '">';
+			$output .= $result['facet_display_value'] . ' <span class="facetwp-counter">(' . $result['counter'] . ')</span>';
 			$output .= '</div>';
 		}
 

--- a/classes/p2p.php
+++ b/classes/p2p.php
@@ -65,7 +65,7 @@ class FacetWP_Facet_P2P {
         ORDER BY $orderby
         LIMIT $limit";
 
-		return $wpdb->get_results( $sql );
+		return $wpdb->get_results( $sql, ARRAY_A );
 	}
 
 	/**


### PR DESCRIPTION
New version of FacetWP assumes that load_values() returns array and not object. You can see this in facetwp/includes/class-facet.php in row 239. Facetwp-p2p load_values() instead returns WordPress default, which is object. You need to change facetwp-p2p load_values() return format and also the format of how one reference to values when rendering facet.