### PR TITLE
Added post type to get_posts query

### DIFF
--- a/facetwp-p2p.php
+++ b/facetwp-p2p.php
@@ -146,6 +146,7 @@ class FWP_P2P {
 			'connected_items'  => (int) $params['post_id'],
 			'nopaging'         => true,
 			'suppress_filters' => false
+			'post_type'        => $post_ptype,
 		) );
 
 		//Index each connected posts


### PR DESCRIPTION
For some reason, in some situations, not having the post type in a p2p query doesn't provide any results.